### PR TITLE
Widen version of the typescript peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tslib": "^2.0.3"
   },
   "peerDependencies": {
-    "typescript": "~4.0.2 || ~4.1.2"
+    "typescript": "^4"
   },
   "devDependencies": {
     "@d-fischer/eslint-config": "^2.0.6",


### PR DESCRIPTION
Yarn is currently giving warnings when using latest version of TypeScript. As it is a peer dependency I recommend widening to accept any version within v4.