### PR TITLE
bump rimraf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,10 @@
     "@oclif/errors": "^1.3.5",
     "@oclif/plugin-help": "^5.1.12",
     "@types/node": "^14.18.13",
-    "@types/rimraf": "^3.0.0",
     "@types/toposort": "^2.0.3",
     "chalk": "^4.1.0",
     "ora": "^5.1.0",
-    "rimraf": "^3.0.2",
+    "rimraf": "^5.0.5",
     "toposort": "^2.0.2",
     "tslib": "^2.0.3"
   },

--- a/src/project/modes/SimpleProjectMode.ts
+++ b/src/project/modes/SimpleProjectMode.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
-import * as _rimraf from 'rimraf';
+import { rimraf } from 'rimraf';
 import * as ts from 'typescript';
-import { promisify } from 'util';
 import { renameOutputFilesToMjs } from '../../mjsRename';
 import { exit, handleDiagnostics } from '../../util';
 import type { WrapperOptions } from '../compile';
@@ -9,8 +8,6 @@ import { hoistExports } from '../transformers/hoistExports';
 import { resolveModulePaths } from '../transformers/resolveModulePaths';
 import { splitEnumExports } from '../transformers/splitEnumExports';
 import type { ProjectMode } from './ProjectMode';
-
-const rimraf = promisify(_rimraf);
 
 export class SimpleProjectMode implements ProjectMode {
 	private _cjsCompilerHost?: ts.CompilerHost;


### PR DESCRIPTION
When I updated several packages in my project to the latest major versions I faced an issue with `tsukuru`:

```
yarn rebuild    
yarn run v1.22.19
$ tsukuru --clean
✔ Cleaning CJS outputs (25ms)
⠼ Checking & building changed projects for CJS...

node_modules/@types/rimraf/index.d.ts:33:21 - error TS2694: Namespace '"{PATH}/node_modules/glob/dist/commonjs/index"' has no exported member 'IOptions'.

33         glob?: glob.IOptions | false | undefined;
                       ~~~~~~~~

Errors occurred before emitting. Exiting.
Process exiting with error code '1'.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Seems like some packages conflict with `@types/rimraf` (`lerna@7.3.0` for example). If I manually remove `@types/rimraf` from `node_modules` it works again.  Updating `rimraf` to the latest version (`5.0.5`) and removing `@types/rimraf` package solves the problem as well (tested locally using `yalc`). So, can I bump `rimraf` here or do you have any reasons to stay on `3.x.x`?